### PR TITLE
Update to major new versions of most dependencies

### DIFF
--- a/rust/cmsis-cffi/Cargo.toml
+++ b/rust/cmsis-cffi/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 ctor = "0.1.15"
 log = "0.4.8"
-simplelog = "0.8.0"
+simplelog = "0.9.0"
 failure = "0.1.1"
 cmsis-pack = { path = "../cmsis-pack" }

--- a/rust/cmsis-cli/Cargo.toml
+++ b/rust/cmsis-cli/Cargo.toml
@@ -17,6 +17,6 @@ app_dirs = "1.2.1"
 clap = "2.33.1"
 failure = "0.1.1"
 log = "0.4.8"
-simplelog = "0.8.0"
+simplelog = "0.9.0"
 pbr = "^1.0.0"
 cmsis-pack = { path="../cmsis-pack" }

--- a/rust/cmsis-pack/Cargo.toml
+++ b/rust/cmsis-pack/Cargo.toml
@@ -12,17 +12,18 @@ categories = ["embedded", "hardware-support", "development-tools::debugging"]
 keywords = ["embedded", "cmsis"]
 
 [dependencies]
+bytes = "0.5.5"
 failure = "0.1.1"
-futures = "0.1.29"
+futures = "0.3.5"
 log = "0.4.8"
 minidom = "^0.12.0"
 quick-xml = "0.17.2"
-reqwest = { version = "0.9.24", default_features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.10.4", default_features = false, features = ["rustls-tls", "stream"] }
 rustc-demangle = "0.1.16"
-serde = "^1.0.89"
-serde_derive = "^1.0.89"
+serde = { version = "^1.0.114", features = ["derive"] }
+serde_derive = "^1.0.114"
 serde_json = "1.0"
-tokio-core = "0.1.17"
+tokio = { version = "0.2.21", features = ["macros", "rt-threaded", "stream"] }
 
 [dev-dependencies]
 time = "0.2.16"

--- a/rust/cmsis-pack/Cargo.toml
+++ b/rust/cmsis-pack/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 authors = ["Jimmy Brisson <theotherjimmy@gmail.com>",
-           "Chris Reed <chris.reed@arm.com>",
-           "Mathias Brossard <mathias.brossard@arm.com>"]
+    "Chris Reed <chris.reed@arm.com>",
+    "Mathias Brossard <mathias.brossard@arm.com>"]
 name = "cmsis-pack"
-repository = "https://github.com/ARMmbed/cmsis-pack-manager"
+repository = "https://github.com/pyocd/cmsis-pack-manager"
 version = "0.2.0"
 edition = "2018"
 description = "Rust crate for managing CMSIS PACKs"
@@ -12,18 +12,23 @@ categories = ["embedded", "hardware-support", "development-tools::debugging"]
 keywords = ["embedded", "cmsis"]
 
 [dependencies]
-bytes = "0.5.5"
+bytes = "1.0"
 failure = "0.1.1"
-futures = "0.3.5"
+futures = "0.3.8"
 log = "0.4.8"
 minidom = "^0.12.0"
 quick-xml = "0.17.2"
-reqwest = { version = "0.10.4", default_features = false, features = ["rustls-tls", "stream"] }
 rustc-demangle = "0.1.16"
-serde = { version = "^1.0.114", features = ["derive"] }
-serde_derive = "^1.0.114"
+serde = { version = "1.0.118", features = ["derive"] }
+serde_derive = "1.0.118"
 serde_json = "1.0"
-tokio = { version = "0.2.21", features = ["macros", "rt-threaded", "stream"] }
+tokio = { version = "1.0", features = ["macros", "rt"] }
+
+[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
+reqwest = { version = "0.11.0", default_features = false, features = ["native-tls", "trust-dns", "stream"] }
+
+[target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
+reqwest = { version = "0.11.0", default_features = false, features = ["rustls-tls", "trust-dns", "stream"] }
 
 [dev-dependencies]
 time = "0.2.16"

--- a/rust/cmsis-pack/src/lib.rs
+++ b/rust/cmsis-pack/src/lib.rs
@@ -13,4 +13,4 @@ extern crate reqwest;
 extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
-extern crate tokio_core;
+extern crate tokio;

--- a/rust/cmsis-pack/src/update/mod.rs
+++ b/rust/cmsis-pack/src/update/mod.rs
@@ -18,8 +18,7 @@ where
     P: DownloadProgress,
     D: DownloadConfig,
 {
-    let mut rt = runtime::Builder::new()
-        .threaded_scheduler()
+    let rt = runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
 
@@ -34,8 +33,7 @@ where
     P: DownloadProgress + 'a,
     D: DownloadConfig,
 {
-    let mut rt = runtime::Builder::new()
-        .threaded_scheduler()
+    let rt = runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
 


### PR DESCRIPTION
- `tokio` 1.0
- `bytes` 1.0
- `reqwest` 0.11
  - Uses `native-tls` on Mac/Windows and `rustls-tls` on Linux.
  - Uses asynchronous DNS resolver.
