### PR TITLE
cmsis-pack: demote "Working on" log messages to debug.

### DIFF
--- a/rust/cmsis-pack/src/pdsc/component.rs
+++ b/rust/cmsis-pack/src/pdsc/component.rs
@@ -124,7 +124,7 @@ impl FromElem for ComponentBuilder {
         let sub_group_string = sub_group.clone().unwrap_or_else(|| "SubGroup".into());
         let files = get_child_no_ns(e, "files")
             .map(move |child| {
-                log::info!(
+                log::debug!(
                     "Working on {}::{}::{}::{}",
                     vendor_string,
                     class_string,

--- a/rust/cmsis-pack/src/pdsc/mod.rs
+++ b/rust/cmsis-pack/src/pdsc/mod.rs
@@ -122,7 +122,7 @@ impl FromElem for Package {
         let description: String = child_text(e, "description", "package")?;
         let vendor: String = child_text(e, "vendor", "package")?;
         let url: String = child_text(e, "url", "package")?;
-        log::info!("Working on {}::{}", vendor, name,);
+        log::debug!("Working on {}::{}", vendor, name,);
         let components = get_child_no_ns(e, "components")
             .and_then(|c| ComponentBuilders::from_elem(c).ok_warn())
             .unwrap_or_default();


### PR DESCRIPTION
There were far too many info logs being spewed during an index update or even single pack install.