### PR TITLE
cmsis-cli: change app name to "cmsis-pack-manager" to match Python.

### DIFF
--- a/rust/cmsis-cli/src/config.rs
+++ b/rust/cmsis-cli/src/config.rs
@@ -24,7 +24,7 @@ impl DownloadConfig for Config {
 impl Config {
     pub fn new() -> Result<Config, Error> {
         let app_info = AppInfo {
-            name: "cmsis-pack",
+            name: "cmsis-pack-manager",
             author: "Arm",
         };
         let pack_store = app_root(AppDataType::UserData, &app_info)?;


### PR DESCRIPTION
If one were to run cmsis-cli and the Python tool (or pyocd) to update the index, two user data directories would be created. One called "cmsis-pack", created by cmsis-cli, and the other "cmsis-pack-manager" created by the Python code. This simple change fixes that so that both code bases use "cmsis-pack-manager".