### PR TITLE
Migrate tokio-core -> tokio 0.1.

### DIFF
--- a/rust/cmsis-pack/Cargo.toml
+++ b/rust/cmsis-pack/Cargo.toml
@@ -22,7 +22,7 @@ rustc-demangle = "0.1.16"
 serde = "^1.0.89"
 serde_derive = "^1.0.89"
 serde_json = "1.0"
-tokio-core = "0.1.17"
+tokio = "0.1.22"
 
 [dev-dependencies]
 time = "0.2.16"

--- a/rust/cmsis-pack/src/lib.rs
+++ b/rust/cmsis-pack/src/lib.rs
@@ -13,4 +13,3 @@ extern crate reqwest;
 extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
-extern crate tokio_core;

--- a/rust/cmsis-pack/src/update/mod.rs
+++ b/rust/cmsis-pack/src/update/mod.rs
@@ -1,9 +1,9 @@
 use failure::Error;
 use std::path::PathBuf;
+use tokio::runtime::current_thread::Runtime;
 
 use futures::stream::iter_ok;
 use futures::Stream;
-use tokio_core::reactor::Core;
 
 use crate::pdsc::Package;
 
@@ -21,7 +21,7 @@ where
     P: DownloadProgress,
     D: DownloadConfig,
 {
-    let mut core = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dl_cntx = DownloadContext::new(config, progress)?;
     let fut = {
         let parsed_vidx = dl_cntx.download_vidx_list(vidx_list);
@@ -30,7 +30,7 @@ where
             .flatten();
         dl_cntx.download_stream(pdsc_list).collect()
     };
-    core.run(fut)
+    runtime.block_on(fut)
 }
 
 /// Flatten a list of Vidx Urls into a list of updated CMSIS packs
@@ -40,8 +40,8 @@ where
     P: DownloadProgress + 'a,
     D: DownloadConfig,
 {
-    let mut core = Core::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let dl_cntx = DownloadContext::new(config, progress)?;
     let fut = dl_cntx.download_stream(iter_ok(pdsc_list)).collect();
-    core.run(fut)
+    runtime.block_on(fut)
 }


### PR DESCRIPTION
This should enable a migration to a newer version of futures and a newer
version of tokio in the future. This seems like a good initial step.