### PR TITLE
python-cli: add `print-cache-dir` subcommand

### DIFF
--- a/cmsis_pack_manager/pack_manager.py
+++ b/cmsis_pack_manager/pack_manager.py
@@ -1,6 +1,7 @@
 # ARM Pack Manager
 # Copyright (c) 2017-2021 Arm Limited
 # Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021 Noah Pendleton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -226,6 +227,11 @@ def command_add_packs(cache, path, intersection=False):
     for p in path:
         cache.add_pack_from_path(p)
 
+
+@subcommand('print-cache-dir',
+            help="Print out the cache directory")
+def command_print_cache_dir(cache):
+    print(cache.data_path)
 
 def get_argparse():
     return parser

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -161,3 +161,12 @@ def test_panic_handling():
         assert False
     except:
         pass
+
+def test_print_cache_dir_cli(capsys):
+    sys.argv = ["pack-manager", "print-cache-dir"]
+    cmsis_pack_manager.pack_manager.main()
+    captured = capsys.readouterr()
+
+    c = cmsis_pack_manager.Cache(True, True)
+
+    assert (c.data_path ==  captured.out.strip())


### PR DESCRIPTION
Add a subcommand to the python cli that prints out the cache directory.

This is useful for locating the downloaded packs for extracting
files from them without using the library.

It should be roughly equivalent to:

```bash
❯ python -c \
  'import cmsis_pack_manager; print(cmsis_pack_manager.Cache(False, False).data_path)'
```

Added a test to cover it.