### PR TITLE
Replace failure with anyhow

### DIFF
--- a/rust/cmsis-cffi/Cargo.toml
+++ b/rust/cmsis-cffi/Cargo.toml
@@ -18,5 +18,7 @@ crate-type = ["cdylib"]
 ctor = "0.1.15"
 log = "0.4.8"
 simplelog = "0.10.0"
-failure = "0.1.1"
 cmsis-pack = { version = "0.5.0", path = "../cmsis-pack" }
+anyhow = { version = "1.0.56", features = ["backtrace"] }
+
+[features]

--- a/rust/cmsis-cffi/src/config.rs
+++ b/rust/cmsis-cffi/src/config.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use cmsis_pack::update::DownloadConfig;
 
-use failure::{err_msg, Error};
+use anyhow::{anyhow, Error};
 
 pub const DEFAULT_VIDX_LIST: [&str; 1] = ["http://www.keil.com/pack/index.pidx"];
 
@@ -33,7 +33,7 @@ impl ConfigBuilder {
         let pack_store = match self.pack_store {
             Some(ps) => ps,
             None => {
-                return Err(err_msg("Pack Store missing"));
+                return Err(anyhow!("Pack Store missing"));
             }
         };
         Ok(Config { pack_store })

--- a/rust/cmsis-cffi/src/lib.rs
+++ b/rust/cmsis-cffi/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate cmsis_pack;
-extern crate failure;
 #[macro_use]
 extern crate ctor;
 
@@ -9,7 +8,7 @@ fn cmsis_cffi_init() {
         simplelog::LevelFilter::Info,
         simplelog::Config::default(),
         simplelog::TerminalMode::Mixed,
-        simplelog::ColorChoice::Auto
+        simplelog::ColorChoice::Auto,
     )
     .unwrap();
 }

--- a/rust/cmsis-cffi/src/pack.rs
+++ b/rust/cmsis-cffi/src/pack.rs
@@ -5,8 +5,6 @@ use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread;
 
-use failure::err_msg;
-
 use crate::config::ConfigBuilder;
 use cmsis_pack::update::install;
 
@@ -51,7 +49,7 @@ cffi! {
                 }))))
             })
         } else {
-            Err(err_msg("update packs received a Null pointer"))
+            Err(anyhow::anyhow!("update packs received a Null pointer"))
         }
     }
 }

--- a/rust/cmsis-cffi/src/pack_index.rs
+++ b/rust/cmsis-cffi/src/pack_index.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
 use std::thread;
 
-use failure::{err_msg, Error};
+use anyhow::{anyhow, Error};
 
 use crate::config::{read_vidx_list, ConfigBuilder, DEFAULT_VIDX_LIST};
 use crate::utils::set_last_error;
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn update_pdsc_poll(ptr: *mut UpdatePoll) -> bool {
                         let response = cont.thread_handle.join();
                         let response = match response {
                             Ok(inner) => inner,
-                            Err(_) => Err(err_msg("thread paniced"))
+                            Err(_) => Err(anyhow!("thread paniced"))
                         };
                         (true, UpdatePoll::Complete(response))
                     } else {
@@ -218,14 +218,14 @@ cffi! {
                         Some(osstr) => {
                             Ok(CString::new(osstr).map(|cstr| cstr.into_raw())?)
                         },
-                        None => Err(err_msg("Could not create a C string from a Rust String"))
+                        None => Err(anyhow!("Could not create a C string from a Rust String"))
                     }
                 } else {
                     Ok(null_mut())
                 }
             })
         } else {
-            Err(err_msg("update pdsc index next called with null"))
+            Err(anyhow!("update pdsc index next called with null"))
         }
     }
 }
@@ -239,7 +239,7 @@ cffi! {
                 Ok(())
             })
         } else {
-            Err(err_msg("update pdsc index push called with null"))
+            Err(anyhow!("update pdsc index push called with null"))
         }
     }
 }

--- a/rust/cmsis-cffi/src/pdsc.rs
+++ b/rust/cmsis-cffi/src/pdsc.rs
@@ -3,8 +3,6 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::path::{Path, PathBuf};
 
-use failure::err_msg;
-
 use cmsis_pack::pdsc::{dump_devices, Package};
 use cmsis_pack::utils::FromElem;
 use cmsis_pack::utils::ResultLogExt;
@@ -55,10 +53,10 @@ cffi! {
             if pathbuf.exists() {
                 Ok(Box::into_raw(Box::new(UpdateReturn::from_vec(vec![pathbuf]))))
             } else {
-                Err(err_msg(format!("Could not find file {:?}", &pathbuf)))
+                Err(anyhow::anyhow!(format!("Could not find file {:?}", &pathbuf)))
             }
         } else {
-            Err(err_msg("Null passed into pack_from_path"))
+            Err(anyhow::anyhow!("Null passed into pack_from_path"))
         }
     }
 }
@@ -74,7 +72,7 @@ cffi! {
                         .collect()))))
             })
         } else {
-            Err(err_msg("Null Passed into parse packs."))
+            Err(anyhow::anyhow!("Null Passed into parse packs."))
         }
     }
 }

--- a/rust/cmsis-cffi/src/utils.rs
+++ b/rust/cmsis-cffi/src/utils.rs
@@ -7,7 +7,7 @@ use std::panic;
 use std::ptr;
 use std::thread;
 
-use failure::{err_msg, Error};
+use anyhow::Error;
 
 thread_local! {
     pub static LAST_ERROR: RefCell<Option<Error>> = RefCell::new(None);
@@ -64,7 +64,7 @@ pub unsafe fn set_panic_hook() {
             None => format!("thread '{}' panicked with '{}'", thread, message),
         };
 
-        set_last_error(err_msg(description))
+        set_last_error(anyhow::anyhow!(description))
     }));
 }
 

--- a/rust/cmsis-cli/Cargo.toml
+++ b/rust/cmsis-cli/Cargo.toml
@@ -20,8 +20,10 @@ path = "src/main.rs"
 [dependencies]
 directories = "4"
 clap = "2.33.1"
-failure = "0.1.1"
 log = "0.4.8"
 simplelog = "0.10.0"
 pbr = "^1.0.0"
 cmsis-pack = { version = "0.5.0", path = "../cmsis-pack" }
+anyhow = "1.0.56"
+
+[features]

--- a/rust/cmsis-cli/src/config.rs
+++ b/rust/cmsis-cli/src/config.rs
@@ -4,7 +4,7 @@ use std::fs::{create_dir_all, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 
-use failure::Error;
+use anyhow::Error;
 
 use cmsis_pack::update::DownloadConfig;
 
@@ -25,7 +25,7 @@ impl Config {
     pub fn new() -> Result<Config, Error> {
         let proj_dir = match ProjectDirs::from("", "", "cmsis-pack-manager") {
             Some(p) => p,
-            None => { return Err(failure::err_msg("Could not determine home directory")) }
+            None => return Err(anyhow::anyhow!("Could not determine home directory")),
         };
 
         let pack_store = proj_dir.config_dir().to_path_buf();

--- a/rust/cmsis-cli/src/lib.rs
+++ b/rust/cmsis-cli/src/lib.rs
@@ -1,9 +1,8 @@
 extern crate clap;
-extern crate failure;
 extern crate pbr;
 
+use anyhow::Error;
 use clap::{App, Arg, ArgMatches, SubCommand};
-use failure::Error;
 use pbr::ProgressBar;
 use std::io::Stdout;
 use std::path::Path;

--- a/rust/cmsis-cli/src/main.rs
+++ b/rust/cmsis-cli/src/main.rs
@@ -1,11 +1,11 @@
 extern crate clap;
 
+use anyhow::Error;
 use clap::{App, Arg};
 use cmsis_cli::{
     check_args, check_command, dump_devices_args, dump_devices_command, install_args,
     install_command, update_args, update_command, Config,
 };
-use failure::Error;
 
 fn main() {
     // Note: This argument parser should do nothing more than handle
@@ -25,7 +25,7 @@ fn main() {
         simplelog::LevelFilter::Info,
         simplelog::Config::default(),
         simplelog::TerminalMode::Mixed,
-        simplelog::ColorChoice::Auto
+        simplelog::ColorChoice::Auto,
     )
     .unwrap();
     log::debug!("Logging ready.");

--- a/rust/cmsis-pack/Cargo.toml
+++ b/rust/cmsis-pack/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 
 [dependencies]
 bytes = "1.0"
-failure = "0.1.1"
 futures = "0.3.8"
 log = "0.4.8"
 minidom = "0.12.0"
@@ -23,6 +22,7 @@ serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["macros", "rt"] }
 reqwest = { version = "0.11.0", default_features = false, features = ["rustls-tls", "trust-dns", "stream"] }
+anyhow = "1.0.56"
 
 [dev-dependencies]
 time = "0.3.3"

--- a/rust/cmsis-pack/src/lib.rs
+++ b/rust/cmsis-pack/src/lib.rs
@@ -4,7 +4,6 @@ pub mod update;
 #[macro_use]
 pub mod utils;
 
-extern crate failure;
 extern crate futures;
 extern crate log;
 extern crate minidom;

--- a/rust/cmsis-pack/src/pack_index/mod.rs
+++ b/rust/cmsis-pack/src/pack_index/mod.rs
@@ -1,5 +1,5 @@
 use crate::utils::prelude::*;
-use failure::Error;
+use anyhow::Error;
 use minidom::Element;
 
 #[derive(Debug, Clone)]

--- a/rust/cmsis-pack/src/pdsc/component.rs
+++ b/rust/cmsis-pack/src/pdsc/component.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use failure::{format_err, Error};
+use anyhow::{format_err, Error};
 use minidom::Element;
 use serde::Serialize;
 

--- a/rust/cmsis-pack/src/pdsc/condition.rs
+++ b/rust/cmsis-pack/src/pdsc/condition.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::Error;
 use minidom::Element;
 
 use crate::utils::prelude::*;

--- a/rust/cmsis-pack/src/pdsc/device.rs
+++ b/rust/cmsis-pack/src/pdsc/device.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use crate::utils::prelude::*;
-use failure::{format_err, Error};
+use anyhow::{format_err, Error};
 use minidom::Element;
 use serde::{Deserialize, Serialize};
 

--- a/rust/cmsis-pack/src/pdsc/mod.rs
+++ b/rust/cmsis-pack/src/pdsc/mod.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 use std::path::Path;
 
 use crate::utils::prelude::*;
-use failure::{format_err, Error};
+use anyhow::{format_err, Error};
 
 mod component;
 mod condition;

--- a/rust/cmsis-pack/src/update/mod.rs
+++ b/rust/cmsis-pack/src/update/mod.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::Error;
 use std::path::PathBuf;
 use tokio::runtime;
 

--- a/rust/cmsis-pack/src/utils/parse.rs
+++ b/rust/cmsis-pack/src/utils/parse.rs
@@ -4,10 +4,10 @@ use std::path::Path;
 use std::str::FromStr;
 
 use crate::utils::ResultLogExt;
-use minidom::{Children, Element};
 use minidom::quick_xml::Reader;
+use minidom::{Children, Element};
 
-use failure::{format_err, Error};
+use anyhow::{format_err, Error};
 
 pub fn attr_map<'a, T>(from: &'a Element, name: &str, elemname: &'static str) -> Result<T, Error>
 where


### PR DESCRIPTION
failure is not maintained anymore, and anyhow is the recommended replacement.

This also helps with integration into probe-rs, since we're also using anyhow there.

I'm not sure if this also requires changes to the python code,  but building the wheel seems to have worked.