### PR TITLE
CPM: Rust: Check status code before saving contents

### DIFF
--- a/rust/cmsis-pack/src/update/download.rs
+++ b/rust/cmsis-pack/src/update/download.rs
@@ -186,7 +186,14 @@ where
         let res = self.client.get(source).send().await;
 
         match res {
-            Ok(r) => self.save_response(r, dest).await,
+            Ok(r) => {
+                let rc = r.status().as_u16();
+                if rc >= 400 {
+                    Err(anyhow!(format!("Response code in invalid range: {}", rc).to_string()))
+                } else {
+                    self.save_response(r, dest).await
+                }
+            },
             Err(err) => Err(anyhow!(err.to_string())),
         }
     }


### PR DESCRIPTION
The current implementation does not check HTTP status code except those handled internally by reqwest. This patch added an additional check against these invalid status codes by simply comparing with 400, so invalid response payloads are not saved to the disk and user may retry later by re-invoking the update command.

Signed-off-by: Yilin Sun <imi415@imi.moe>