### PR TITLE
Add support for STAR-MC1 by Arm China

### DIFF
--- a/rust/cmsis-pack/src/pdsc/device.rs
+++ b/rust/cmsis-pack/src/pdsc/device.rs
@@ -37,6 +37,7 @@ pub enum Core {
     CortexA57,
     CortexA72,
     CortexA73,
+    StarMC1,
 }
 
 impl FromStr for Core {
@@ -71,6 +72,7 @@ impl FromStr for Core {
             "Cortex-A57" => Ok(Core::CortexA57),
             "Cortex-A72" => Ok(Core::CortexA72),
             "Cortex-A73" => Ok(Core::CortexA73),
+            "Star-MC1" => Ok(Core::StarMC1),
             unknown => Err(format_err!("Unknown core {}", unknown)),
         }
     }


### PR DESCRIPTION
STAR-MC1 is a variant of Armv8-M with TrustZone designed by Arm China.


Spec:

https://github.com/ARM-software/CMSIS-Driver_Validation/blob/37250825309186a42a83a8e4f21b455c48b70833/ARM.CMSIS-Driver_Validation.pdsc#L44

See-also: https://www.armchina.com/mountain?infoId=160 (in Chinese)
See-also: https://github.com/ARM-software/CMSIS_5/commit/4745ac94566d761ca895267f5074620071660858
