### PR TITLE
Make CMSIS pack downloading feature optional 

### DIFF
--- a/rust/cmsis-cffi/src/config.rs
+++ b/rust/cmsis-cffi/src/config.rs
@@ -2,6 +2,7 @@ use std::fs::{create_dir_all, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "pack-download")]
 use cmsis_pack::update::DownloadConfig;
 
 use anyhow::{anyhow, Error};
@@ -16,6 +17,7 @@ pub struct ConfigBuilder {
     pack_store: Option<PathBuf>,
 }
 
+#[cfg(feature = "pack-download")]
 impl DownloadConfig for Config {
     fn pack_store(&self) -> PathBuf {
         self.pack_store.clone()

--- a/rust/cmsis-cffi/src/pack.rs
+++ b/rust/cmsis-cffi/src/pack.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pack-download")]
+
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/rust/cmsis-cffi/src/pack_index.rs
+++ b/rust/cmsis-cffi/src/pack_index.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_safety_doc)]
+
 use std::borrow::{Borrow, BorrowMut};
 use std::ffi::{CStr, CString};
 use std::mem;
@@ -6,15 +7,23 @@ use std::os::raw::c_char;
 use std::path::PathBuf;
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, Sender};
+
+#[cfg(feature = "pack-download")]
+use std::sync::mpsc::{channel, Sender};
+use std::sync::mpsc::Receiver;
 use std::sync::Arc;
 use std::thread;
 
 use anyhow::{anyhow, Error};
 
+#[cfg(feature = "pack-download")]
 use crate::config::{read_vidx_list, ConfigBuilder, DEFAULT_VIDX_LIST};
 use crate::utils::set_last_error;
+
+#[cfg(feature = "pack-download")]
 use cmsis_pack::update::update;
+
+#[cfg(feature = "pack-download")]
 use cmsis_pack::update::DownloadProgress;
 
 pub struct UpdateReturn(pub(crate) Vec<PathBuf>);
@@ -31,14 +40,18 @@ pub struct DownloadUpdate {
     pub size: usize,
 }
 
+
+#[cfg(feature = "pack-download")]
 pub(crate) struct DownloadSender(Sender<DownloadUpdate>);
 
+#[cfg(feature = "pack-download")]
 impl DownloadSender {
     pub(crate) fn from_sender(from: Sender<DownloadUpdate>) -> Self {
         DownloadSender(from)
     }
 }
 
+#[cfg(feature = "pack-download")]
 impl DownloadProgress for DownloadSender {
     fn size(&self, size: usize) {
         let _ = self.0.send(DownloadUpdate {
@@ -81,6 +94,7 @@ impl UpdateReturn {
     }
 }
 
+#[cfg(feature = "pack-download")]
 cffi! {
     fn update_pdsc_index(
         pack_store: *const c_char,

--- a/rust/cmsis-pack/Cargo.toml
+++ b/rust/cmsis-pack/Cargo.toml
@@ -19,12 +19,13 @@ log = "0.4.8"
 minidom = "0.12.0"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.0", features = ["macros", "rt"] }
-reqwest = { version = "0.11.0", default_features = false, features = ["rustls-tls-native-roots", "trust-dns", "stream"] }
+tokio = { version = "1.0", features = ["macros", "rt"], optional = true }
+reqwest = { version = "0.11.0", default_features = false, features = ["rustls-tls-native-roots", "trust-dns", "stream"], optional = true }
 anyhow = "1.0.56"
 
 [dev-dependencies]
 time = "0.3.3"
 
 [features]
-default = []
+default = ["pack-download"]
+pack-download = ["dep:tokio", "dep:reqwest"]

--- a/rust/cmsis-pack/src/lib.rs
+++ b/rust/cmsis-pack/src/lib.rs
@@ -7,7 +7,12 @@ pub mod utils;
 extern crate futures;
 extern crate log;
 extern crate minidom;
+
+#[cfg(feature = "pack-download")]
 extern crate reqwest;
+
 extern crate serde;
 extern crate serde_json;
+
+#[cfg(feature = "pack-download")]
 extern crate tokio;

--- a/rust/cmsis-pack/src/update/mod.rs
+++ b/rust/cmsis-pack/src/update/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "pack-download")]
+
 use anyhow::Error;
 use std::path::PathBuf;
 use tokio::runtime;


### PR DESCRIPTION
Hi there,

I've added a Cargo feature flag to make the CMSIS pack downloading feature optional. But of course I left it enabled by default.

The reason why is because I'm making the next version of my [offline firmware programmer tool](https://github.com/huming2207/soul-injector).  I would like to port this library to run it on WebAssembly environment for browser or even port it to ESP32.  There are some platforms like these `xtensa-esp32` or `wasm32-unknown` don't (fully) support for networking and async runtime like Tokio, or they may have binary size constraints. Therefore in order to let this library fits in this scenario, I would like to add in this feature. 

Regards,
Jackson Hu