### PR TITLE
Use Element’s name in logging rather than dupplicated information

### DIFF
--- a/rust/cmsis-cli/src/lib.rs
+++ b/rust/cmsis-cli/src/lib.rs
@@ -139,7 +139,7 @@ pub fn dump_devices_args<'a, 'b>() -> App<'a, 'b> {
 pub fn dump_devices_command<'a>(c: &Config, args: &ArgMatches<'a>) -> Result<(), Error> {
     let files = args
         .value_of("INPUT")
-        .map(|input| vec![Box::new(Path::new(input)).to_path_buf()]);
+        .map(|input| vec![Path::new(input).to_path_buf()]);
     let filenames = files
         .or_else(|| {
             c.pack_store.read_dir().ok().map(|rd| {

--- a/rust/cmsis-pack/src/pack_index/mod.rs
+++ b/rust/cmsis-pack/src/pack_index/mod.rs
@@ -34,14 +34,14 @@ impl FromElem for PdscRef {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         assert_root_name(e, "pdsc")?;
         Ok(Self {
-            url: attr_map(e, "url", "pdsc")?,
-            vendor: attr_map(e, "vendor", "pdsc")?,
-            name: attr_map(e, "name", "pdsc")?,
-            version: attr_map(e, "version", "pdsc")?,
-            date: attr_map(e, "date", "pdsc").ok(),
-            deprecated: attr_map(e, "deprecated", "pdsc").ok(),
-            replacement: attr_map(e, "replacement", "pdsc").ok(),
-            size: attr_map(e, "size", "pdsc").ok(),
+            url: attr_map(e, "url")?,
+            vendor: attr_map(e, "vendor")?,
+            name: attr_map(e, "name")?,
+            version: attr_map(e, "version")?,
+            date: attr_map(e, "date").ok(),
+            deprecated: attr_map(e, "deprecated").ok(),
+            replacement: attr_map(e, "replacement").ok(),
+            size: attr_map(e, "size").ok(),
         })
     }
 }
@@ -50,9 +50,9 @@ impl FromElem for Pidx {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         assert_root_name(e, "pidx")?;
         Ok(Self {
-            url: attr_map(e, "url", "pidx")?,
-            vendor: attr_map(e, "vendor", "pidx")?,
-            date: attr_map(e, "date", "pidx").ok(),
+            url: attr_map(e, "url")?,
+            vendor: attr_map(e, "vendor")?,
+            date: attr_map(e, "date").ok(),
         })
     }
 }
@@ -60,8 +60,8 @@ impl FromElem for Pidx {
 impl FromElem for Vidx {
     fn from_elem(root: &Element) -> Result<Self, Error> {
         assert_root_name(root, "index")?;
-        let vendor = child_text(root, "vendor", "index")?;
-        let url = child_text(root, "url", "index")?;
+        let vendor = child_text(root, "vendor")?;
+        let url = child_text(root, "url")?;
         Ok(Vidx {
             vendor,
             url,

--- a/rust/cmsis-pack/src/pdsc/component.rs
+++ b/rust/cmsis-pack/src/pdsc/component.rs
@@ -82,13 +82,13 @@ impl FromElem for FileRef {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         assert_root_name(e, "file")?;
         Ok(Self {
-            path: attr_map(e, "name", "file")?,
-            category: attr_parse(e, "category", "file")?,
-            attr: attr_parse(e, "attr", "file").ok(),
-            condition: attr_map(e, "condition", "file").ok(),
-            select: attr_map(e, "select", "file").ok(),
-            src: attr_map(e, "src", "file").ok(),
-            version: attr_map(e, "version", "file").ok(),
+            path: attr_map(e, "name")?,
+            category: attr_parse(e, "category")?,
+            attr: attr_parse(e, "attr").ok(),
+            condition: attr_map(e, "condition").ok(),
+            select: attr_map(e, "select").ok(),
+            src: attr_map(e, "src").ok(),
+            version: attr_map(e, "version").ok(),
         })
     }
 }
@@ -114,10 +114,10 @@ pub struct ComponentBuilder {
 impl FromElem for ComponentBuilder {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         assert_root_name(e, "component")?;
-        let vendor: Option<String> = attr_map(e, "Cvendor", "component").ok();
-        let class: Option<String> = attr_map(e, "Cclass", "component").ok();
-        let group: Option<String> = attr_map(e, "Cgroup", "component").ok();
-        let sub_group: Option<String> = attr_map(e, "Csub", "component").ok();
+        let vendor: Option<String> = attr_map(e, "Cvendor").ok();
+        let class: Option<String> = attr_map(e, "Cclass").ok();
+        let group: Option<String> = attr_map(e, "Cgroup").ok();
+        let sub_group: Option<String> = attr_map(e, "Csub").ok();
         let vendor_string = vendor.clone().unwrap_or_else(|| "Vendor".into());
         let class_string = class.clone().unwrap_or_else(|| "Class".into());
         let group_string = group.clone().unwrap_or_else(|| "Group".into());
@@ -139,17 +139,17 @@ impl FromElem for ComponentBuilder {
             class,
             group,
             sub_group,
-            version: attr_map(e, "Cversion", "component").ok(),
-            variant: attr_map(e, "Cvariant", "component").ok(),
-            api_version: attr_map(e, "Capiversion", "component").ok(),
-            condition: attr_map(e, "condition", "component").ok(),
-            max_instances: attr_parse(e, "maxInstances", "component").ok(),
-            is_default: attr_parse(e, "isDefaultVariant", "component").unwrap_or(true),
-            description: child_text(e, "description", "component")?,
-            deprecated: child_text(e, "deprecated", "component")
+            version: attr_map(e, "Cversion").ok(),
+            variant: attr_map(e, "Cvariant").ok(),
+            api_version: attr_map(e, "Capiversion").ok(),
+            condition: attr_map(e, "condition").ok(),
+            max_instances: attr_parse(e, "maxInstances").ok(),
+            is_default: attr_parse(e, "isDefaultVariant").unwrap_or(true),
+            description: child_text(e, "description")?,
+            deprecated: child_text(e, "deprecated")
                 .map(|s| s.parse().unwrap_or(false))
                 .unwrap_or(false),
-            rte_addition: child_text(e, "RTE_components_h", "component").unwrap_or_default(),
+            rte_addition: child_text(e, "RTE_components_h").unwrap_or_default(),
             files,
         })
     }
@@ -189,9 +189,9 @@ impl Bundle {
 impl FromElem for Bundle {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         assert_root_name(e, "bundle")?;
-        let name: String = attr_map(e, "Cbundle", "bundle")?;
-        let class: String = attr_map(e, "Cclass", "bundle")?;
-        let version: String = attr_map(e, "Cversion", "bundle")?;
+        let name: String = attr_map(e, "Cbundle")?;
+        let class: String = attr_map(e, "Cclass")?;
+        let version: String = attr_map(e, "Cversion")?;
         // let l = l.new(o!("Bundle" => name.clone(),
         //                  "Class" => class.clone(),
         //                  "Version" => version.clone()));
@@ -209,9 +209,9 @@ impl FromElem for Bundle {
             name,
             class,
             version,
-            vendor: attr_map(e, "Cvendor", "bundle").ok(),
-            description: child_text(e, "description", "bundle")?,
-            doc: child_text(e, "doc", "bundle")?,
+            vendor: attr_map(e, "Cvendor").ok(),
+            description: child_text(e, "description")?,
+            doc: child_text(e, "doc")?,
             components,
         })
     }

--- a/rust/cmsis-pack/src/pdsc/condition.rs
+++ b/rust/cmsis-pack/src/pdsc/condition.rs
@@ -14,11 +14,11 @@ pub struct ConditionComponent {
 impl FromElem for ConditionComponent {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         Ok(ConditionComponent {
-            device_family: attr_map(e, "Dfamily", "condition").ok(),
-            device_sub_family: attr_map(e, "Dsubfamily", "condition").ok(),
-            device_variant: attr_map(e, "Dvariant", "condition").ok(),
-            device_vendor: attr_map(e, "Dvendor", "condition").ok(),
-            device_name: attr_map(e, "Dname", "condition").ok(),
+            device_family: attr_map(e, "Dfamily").ok(),
+            device_sub_family: attr_map(e, "Dsubfamily").ok(),
+            device_variant: attr_map(e, "Dvariant").ok(),
+            device_vendor: attr_map(e, "Dvendor").ok(),
+            device_name: attr_map(e, "Dname").ok(),
         })
     }
 }
@@ -54,7 +54,7 @@ impl FromElem for Condition {
             }
         }
         Ok(Condition {
-            id: attr_map(e, "id", "condition")?,
+            id: attr_map(e, "id")?,
             accept,
             deny,
             require,

--- a/rust/cmsis-pack/src/pdsc/device.rs
+++ b/rust/cmsis-pack/src/pdsc/device.rs
@@ -225,11 +225,11 @@ impl ProcessorBuilder {
 impl FromElem for ProcessorBuilder {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         Ok(ProcessorBuilder {
-            core: attr_parse(e, "Dcore", "processor").ok(),
-            units: attr_parse(e, "Punits", "processor").ok(),
-            fpu: attr_parse(e, "Dfpu", "processor").ok(),
-            mpu: attr_parse(e, "Dmpu", "processor").ok(),
-            name: attr_parse(e, "Pname", "processor").ok(),
+            core: attr_parse(e, "Dcore").ok(),
+            units: attr_parse(e, "Punits").ok(),
+            fpu: attr_parse(e, "Dfpu").ok(),
+            mpu: attr_parse(e, "Dmpu").ok(),
+            name: attr_parse(e, "Pname").ok(),
         })
     }
 }
@@ -312,14 +312,14 @@ impl DebugBuilder {
 impl FromElem for DebugBuilder {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         Ok(DebugBuilder {
-            ap: attr_parse(e, "__ap", "debug").ok(),
-            dp: attr_parse(e, "__dp", "debug").ok(),
-            apid: attr_parse(e, "__apid", "debug").ok(),
-            address: attr_parse(e, "address", "debug").ok(),
-            svd: attr_parse(e, "svd", "debug").ok(),
-            name: attr_parse(e, "Pname", "debug").ok(),
-            unit: attr_parse(e, "Punit", "debug").ok(),
-            default_reset_sequence: attr_parse(e, "defaultResetSequence", "debug").ok(),
+            ap: attr_parse(e, "__ap").ok(),
+            dp: attr_parse(e, "__dp").ok(),
+            apid: attr_parse(e, "__apid").ok(),
+            address: attr_parse(e, "address").ok(),
+            svd: attr_parse(e, "svd").ok(),
+            name: attr_parse(e, "Pname").ok(),
+            unit: attr_parse(e, "Punit").ok(),
+            default_reset_sequence: attr_parse(e, "defaultResetSequence").ok(),
         })
     }
 }
@@ -446,12 +446,12 @@ impl FromElem for MemElem {
             .map(|s| s.to_string())
             .ok_or_else(|| format_err!("No name found for memory"))?;
         let p_name = e.attr("Pname").map(|s| s.to_string());
-        let start = attr_parse_hex(e, "start", "memory")?;
-        let size = attr_parse_hex(e, "size", "memory")?;
-        let startup = attr_parse(e, "startup", "memory")
+        let start = attr_parse_hex(e, "start")?;
+        let size = attr_parse_hex(e, "size")?;
+        let startup = attr_parse(e, "startup")
             .map(|nb: NumberBool| nb.into())
             .unwrap_or_default();
-        let default = attr_parse(e, "default", "memory")
+        let default = attr_parse(e, "default")
             .map(|nb: NumberBool| nb.into())
             .unwrap_or_default();
         Ok(MemElem(
@@ -520,20 +520,18 @@ pub struct Algorithm {
 
 impl FromElem for Algorithm {
     fn from_elem(e: &Element) -> Result<Self, Error> {
-        let default = attr_parse(e, "default", "memory")
+        let default = attr_parse(e, "default")
             .map(|nb: NumberBool| nb.into())
             .unwrap_or_default();
 
-        let file_name: &str = attr_map(e, "name", "algorithm")?;
-        let style = attr_parse(e, "style", "algorithm")
-            .ok()
-            .unwrap_or(AlgorithmStyle::Keil);
+        let file_name: &str = attr_map(e, "name")?;
+        let style = attr_parse(e, "style").ok().unwrap_or(AlgorithmStyle::Keil);
         Ok(Self {
             file_name: file_name.replace("\\", "/").into(),
-            start: attr_parse_hex(e, "start", "algorithm")?,
-            size: attr_parse_hex(e, "size", "algorithm")?,
-            ram_start: attr_parse_hex(e, "RAMstart", "algorithm").ok(),
-            ram_size: attr_parse_hex(e, "RAMsize", "algorithm").ok(),
+            start: attr_parse_hex(e, "start")?,
+            size: attr_parse_hex(e, "size")?,
+            ram_start: attr_parse_hex(e, "RAMstart").ok(),
+            ram_size: attr_parse_hex(e, "RAMsize").ok(),
             default,
             style,
         })

--- a/rust/cmsis-pack/src/pdsc/mod.rs
+++ b/rust/cmsis-pack/src/pdsc/mod.rs
@@ -25,7 +25,7 @@ impl FromElem for Release {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         assert_root_name(e, "release")?;
         Ok(Self {
-            version: attr_map(e, "version", "release")?,
+            version: attr_map(e, "version")?,
             text: e.text(),
         })
     }
@@ -117,10 +117,10 @@ pub struct Package {
 impl FromElem for Package {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         assert_root_name(e, "package")?;
-        let name: String = child_text(e, "name", "package")?;
-        let description: String = child_text(e, "description", "package")?;
-        let vendor: String = child_text(e, "vendor", "package")?;
-        let url: String = child_text(e, "url", "package")?;
+        let name: String = child_text(e, "name")?;
+        let description: String = child_text(e, "description")?;
+        let vendor: String = child_text(e, "vendor")?;
+        let url: String = child_text(e, "url")?;
         log::debug!("Working on {}::{}", vendor, name,);
         let components = get_child_no_ns(e, "components")
             .and_then(|c| ComponentBuilders::from_elem(c).ok_warn())
@@ -143,7 +143,7 @@ impl FromElem for Package {
             vendor,
             url,
             components,
-            license: child_text(e, "license", "package").ok(),
+            license: child_text(e, "license").ok(),
             releases,
             conditions,
             devices,
@@ -161,11 +161,11 @@ pub struct Board {
 impl FromElem for Board {
     fn from_elem(e: &Element) -> Result<Self, Error> {
         Ok(Self {
-            name: attr_map(e, "name", "board")?,
+            name: attr_map(e, "name")?,
             mounted_devices: e
                 .children()
                 .flat_map(|c| match c.name() {
-                    "mountedDevice" => attr_map(c, "Dname", "mountedDevice").ok(),
+                    "mountedDevice" => attr_map(c, "Dname").ok(),
                     _ => None,
                 })
                 .collect(),

--- a/rust/cmsis-pack/src/utils/parse.rs
+++ b/rust/cmsis-pack/src/utils/parse.rs
@@ -9,22 +9,18 @@ use minidom::{Children, Element};
 
 use anyhow::{format_err, Error};
 
-pub fn attr_map<'a, T>(from: &'a Element, name: &str, elemname: &'static str) -> Result<T, Error>
+pub fn attr_map<'a, T>(from: &'a Element, name: &str) -> Result<T, Error>
 where
     T: From<&'a str>,
 {
     from.attr(name)
         .map(T::from)
-        .ok_or_else(|| format_err!("{} not found in {} element", name, elemname))
+        .ok_or_else(|| format_err!("{} not found in {} element", name, from.name()))
 }
 
-pub fn attr_parse_hex<'a>(
-    from: &'a Element,
-    name: &str,
-    elemname: &'static str,
-) -> Result<u64, Error> {
+pub fn attr_parse_hex<'a>(from: &'a Element, name: &str) -> Result<u64, Error> {
     from.attr(name)
-        .ok_or_else(|| format_err!("{} not found in {} element", name, elemname))
+        .ok_or_else(|| format_err!("{} not found in {} element", name, from.name()))
         .and_then(|st| {
             if st.starts_with("0x") {
                 u64::from_str_radix(&st[2..], 16).map_err(|e| format_err!("{}", e))
@@ -36,31 +32,23 @@ pub fn attr_parse_hex<'a>(
         })
 }
 
-pub fn attr_parse<'a, T, E>(
-    from: &'a Element,
-    name: &str,
-    elemname: &'static str,
-) -> Result<T, Error>
+pub fn attr_parse<'a, T, E>(from: &'a Element, name: &str) -> Result<T, Error>
 where
     T: FromStr<Err = E>,
     E: Display,
 {
     from.attr(name)
-        .ok_or_else(|| format_err!("{} not found in {} element", name, elemname))
+        .ok_or_else(|| format_err!("{} not found in {} element", name, from.name()))
         .and_then(|st| st.parse::<T>().map_err(|e| format_err!("{}", e)))
 }
 
-pub fn child_text<'a>(
-    from: &'a Element,
-    name: &str,
-    elemname: &'static str,
-) -> Result<String, Error> {
+pub fn child_text<'a>(from: &'a Element, name: &str) -> Result<String, Error> {
     match get_child_no_ns(from, name) {
         Some(child) => Ok(child.text()),
         None => Err(format_err!(
             "child element \"{}\" not found in \"{}\" element",
             name,
-            elemname
+            from.name()
         )),
     }
 }


### PR DESCRIPTION
The element’s name information is duplicated and sometimes inconsistent (like in `Algorithm::from_elem`.

This PR makes the logging rely on the `Element`’s own `.name()` accessor instead.