### PR TITLE
Handle inheritance of <debug> element attributes

### DIFF
--- a/rust/cmsis-pack/src/pdsc/device.rs
+++ b/rust/cmsis-pack/src/pdsc/device.rs
@@ -326,7 +326,7 @@ impl DebugBuilder {
                 ),
                 "accessportV2" => (
                     attr_parse(ap, "__dp").ok(),
-                    attr_parse(ap, "address").ok().map(AccessPort::Address),
+                    attr_parse_hex(ap, "address").ok().map(AccessPort::Address),
                 ),
                 _ => unreachable!(),
             }


### PR DESCRIPTION
The spec states: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/pdsc_family_pg.html#element_debug

> Multiple debug elements can be defined which are either specific to a
> processor identified by attribute Pname, or which apply to all
> connections.

The current implementation did not handle this correctly: it only looked for a single debug element defined on either the device or subfamily. Debug attributes can be defined on the family as well; and if the innermost debug element does not have the attribute we're looking for, we need to look at debug elements on parent elements rather than assuming it's undefined.

This patch is necessary to correctly parse PSOC 6 CMSIS packs, which define debug elements at the family level and define additional attributes at more specific levels:

```xml
<family Dfamily="PSoC 62" Dvendor="Infineon:7">
  <processor Pname="Cortex-M0p" Dcore="Cortex-M0+" DcoreVersion="r0p1" Dfpu="NO_FPU" Dmpu="MPU" Dendian="Little-endian" Dclock="100000000" />
  <processor Pname="Cortex-M4" Dcore="Cortex-M4" DcoreVersion="r0p1" Dfpu="SP_FPU" Dmpu="MPU" Dendian="Little-endian" Dclock="150000000" />
  <debug Pname="Cortex-M0p" __ap="1" defaultResetSequence="ResetProcessor" />
  <debug Pname="Cortex-M4" __ap="2" defaultResetSequence="ResetSystem">
  ....
  <subFamily DsubFamily="CY8C62x4">
    <debug Pname="Cortex-M0p" svd="SVD/psoc6_04.svd" />
    <debug Pname="Cortex-M4" svd="SVD/psoc6_04.svd" />
```